### PR TITLE
Require CherryPy and dateutil

### DIFF
--- a/python-saline.spec
+++ b/python-saline.spec
@@ -19,9 +19,9 @@ BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  %{python_module base}
-Requires:       %{python_module salt}
 Requires:       python-CherryPy
 Requires:       python-python-dateutil
+Requires:       python-salt
 Requires:       config(saline) = %{version}-%{release}
 Requires(post): update-alternatives
 Requires(postun):update-alternatives

--- a/python-saline.spec
+++ b/python-saline.spec
@@ -20,6 +20,8 @@ BuildRequires:  python-rpm-macros
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  %{python_module base}
 Requires:       %{python_module salt}
+Requires:       python-CherryPy
+Requires:       python-python-dateutil
 Requires:       config(saline) = %{version}-%{release}
 Requires(post): update-alternatives
 Requires(postun):update-alternatives


### PR DESCRIPTION
Service cannot start without these modules, hence have the package require them.